### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ key file
 ## Deployment
 
 1. Install the [Google Cloud SDK][2]
-1. `gcloud preview app deploy app.yaml worker.yaml --promote`
+1. `gcloud app deploy app.yaml worker.yaml --promote`
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "npm run unit && npm run integration",
     "cover": "npm run unit-cover && npm run integration-cover",
     "coveralls": "npm run cover && cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js",
-    "deploy": "gcloud preview app deploy app.yaml worker.yaml --version alpha-001 --promote"
+    "deploy": "gcloud app deploy app.yaml worker.yaml --version alpha-001 --promote"
   },
   "dependencies": {
     "@google/cloud-trace": "0.2.0",


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.
